### PR TITLE
change Structure to Inductive where appropriate for 8.6.1 compatibility

### DIFF
--- a/Core/HoareTriples.v
+++ b/Core/HoareTriples.v
@@ -93,7 +93,7 @@ Lemma prog_unfin (W : world) A (s : spec A) (e : DTbin this W s) :
 Proof. by case: e; case. Qed.
 
 (* Packaging the definition into an type, _indexed_ by a specificaion s. *)
-Structure DT (W: world) A :=
+Inductive DT (W: world) A :=
   with_spec (s : spec A) of DTbin this W s.
 
 Definition spec_of W A (e : DT W A) := let: with_spec s _ := e in s.

--- a/Heaps/idynamic.v
+++ b/Heaps/idynamic.v
@@ -24,7 +24,7 @@ Unset Printing Implicit Defensive.
 Section IndexedDynamic.
 Variable (I : Type) (sort : I -> Type).
 
-Structure idynamic := idyn (A : I) of sort A.
+Inductive idynamic := idyn (A : I) of sort A.
 
 Definition idyn_tp (x : idynamic) : I := let: idyn A _ := x in A.
 

--- a/Heaps/pcm.v
+++ b/Heaps/pcm.v
@@ -233,7 +233,7 @@ Module Lift.
 Section Lift.
 Variable A : unlifted.
 
-Structure lift : Type := Undef | Up of A.
+Inductive lift : Type := Undef | Up of A.
 
 Let unit := Up ounit.
 
@@ -355,7 +355,7 @@ Definition maxPCM := Eval hnf in PCM nat maxPCMMixin.
 
 (* mutexes are an unlifted pcm and an equality type *)
 
-Structure mutex := own | nown.
+Inductive mutex := own | nown.
 
 Module MutexUnlift.
 
@@ -494,7 +494,7 @@ Module FinMapPCM.
 Section FinMapPCM.
 Variables (K : ordType) (V : Type).
 
-Structure finmap := Undef | Def of {finMap K -> V}.
+Inductive finmap := Undef | Def of {finMap K -> V}.
 
 Definition valid (f : finmap) :=
   if f is Def _ then true else false.


### PR DESCRIPTION
Coq 8.6.1 no longer treats `Structure` as a synonym for `Inductive` where this would be the reasonable thing. This results in the following type of error messages: `Error: The Record keyword is for types defined using the syntax { ... }.`. In this PR, I change the `Structure` to `Inductive` to make disel compile again, on both 8.6 and 8.6.1.