### PR TITLE
fix safe_string problems and compile OCaml programs with safe_string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ Makefile.coq: _CoqProject
 	coq_makefile -f _CoqProject -o Makefile.coq
 
 TPCMain.d.byte: default
-	ocamlbuild -libs unix -I extraction/TPC -I shims shims/TPCMain.d.byte
+	ocamlbuild -tag safe_string -libs unix -I extraction/TPC -I shims shims/TPCMain.d.byte
 
 CalculatorMain.d.byte: default
-	ocamlbuild -libs unix -I extraction/calculator -I shims shims/CalculatorMain.d.byte
+	ocamlbuild -tag safe_string -libs unix -I extraction/calculator -I shims shims/CalculatorMain.d.byte
 
 .PHONY: default clean install


### PR DESCRIPTION
Due to intermixing of `string` and `bytes` variables, the current shim cannot be compiled with `-safe_string`, which is the default option in the recently released OCaml 4.06.0. This PR fixes this problem and makes all OCaml programs compile with `-safe_string` even on 4.05.0 and earlier.